### PR TITLE
cleanup buildozer spec, load able as git submodule, store sdk/ndk in .android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,7 @@ venv.bak/
 
 # JetBrains stuff
 .idea/
+
+.android/ndk
+.android/sdk
+.buildozer

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".android/able"]
+	path = .android/able
+	url = https://github.com/b3b/able

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -36,7 +36,7 @@ version = 0.6
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = python3,kivy,android,able,lictionary,tatsu,requests,openssl,kivymd
+requirements = libffi,python3,kivy,android,requests,openssl,kivymd,able
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes
 # requirements.source.kivy = ../../kivy
@@ -105,10 +105,10 @@ android.api = 28
 #android.private_storage = True
 
 # (str) Android NDK directory (if empty, it will be automatically downloaded.)
-android.ndk_path = /opt/android-studio/ndk-bundle
+android.ndk_path = ./.android/ndk
 
 # (str) Android SDK directory (if empty, it will be automatically downloaded.)
-android.sdk_path = /opt/Android/Sdk
+android.sdk_path = ./.android/sdk
 
 # (str) ANT directory (if empty, it will be automatically downloaded.)
 #android.ant_path =
@@ -207,7 +207,7 @@ android.arch = armeabi-v7a
 #p4a.source_dir =
 
 # (str) The directory in which python-for-android should look for your own build recipes (if any)
-p4a.local_recipes = ~/able/recipes
+p4a.local_recipes = ./.android/able/recipes
 
 # (str) Filename to the hook for p4a
 #p4a.hook =


### PR DESCRIPTION
This moves default sdk/ndk paths to `.android/sdk` / `.android/ndk` in repository root. If someone needs to keep sdk/ndk in their own common path, they can just do something like:
```
ln -sf /opt/android-studio/ndk-bundle .android/ndk
ln -sf /opt/Android/Sdk .android/sdk
```
...but for new developers this will be a much more sensible default.

Also able is now loaded as a submodule in `.android/able` (as it's not published on pypi) - in order to fetch it properly you need to either use `--recursive` flag when doing `git clone`, or do `git submodule update --init` after cloning.

`.buildozer` and `.android` has been added to gitignore in order to stop pollution of `git status`.